### PR TITLE
[HOTFIX] WK - Change optional chain operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lawmatics/ckeditor5-build-classic",
-  "version": "36.0.8",
+  "version": "36.0.9",
   "description": "Lawmatics' custom CKeditor5 build",
   "main": "./build/ckeditor.js",
   "files": [

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -120,8 +120,12 @@ class MergeFieldPlugin extends Plugin {
     conversion.for('upcast').elementToElement({
       view: { name: 'span', classes: ['mergeField'] },
       model: (viewElement, { writer: modelWriter }) => {
-        const name = viewElement.getChild(0)?.data;
-        if (name) return modelWriter.createElement('mergeField', { name });
+		// Seems that older iOS versions (<= 13) don't handle the optional chaining operator (?.) very well.
+		const element = viewElement.getChild(0);
+		if (element) {
+			const name = element.data;
+			if (name) return modelWriter.createElement('mergeField', { name });
+		}
       }
     });
 


### PR DESCRIPTION
## The Problem

When using older iOS versions (<= 13), the optional chaining operator causes a weird `SyntaxError: Unexpected token '.'`, what's causing our app to not even load the login page. After a lot of debugging and git bisects, I finally found the culprit for this error. This is affecting a lot of customers that try to sign documents using mobile devices.

## The Fix
In order to quickly fix this, I just removed the optional chaining operator.

## Note: I've tried changing the `output.environment` property to make the `optionalChaining` prop false, but it didn't have any effect. So instead of installing Babel and adding a huge overhead of config files, I just removed the operator to quickly fix the problem. We can, for sure, add babel and configure the output as ES5, but that's more than a quick simple hotfix.

