### PR TITLE
disallow contenteditable from htmlSupport in editor defaultConfig

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -313,7 +313,7 @@ ClassicEditor.defaultConfig = {
 				attributes: [
 					{ key: /^on(.*)/i, value: true },
 					{ key: /.*/, value: /(\b)(on\S+)(\s*)=|javascript:|(<\s*)(\/*)script/i },
-		  			{ key: /.*/, value: /data:(?!image\/(png|jpeg|gif|webp))/i },
+					{ key: /.*/, value: /data:(?!image\/(png|jpeg|gif|webp))/i },
 					{ key: 'contenteditable', value: true }
 				]
 			},


### PR DESCRIPTION
Fix: ClassicEditor now removes `contenteditable` attributes in html inserts.
